### PR TITLE
Fix for pallete-based image(converts them to full RGB)

### DIFF
--- a/ocr_with_django/documents/views.py
+++ b/ocr_with_django/documents/views.py
@@ -15,6 +15,7 @@ class OcrView(View):
     def post(self, request, *args, **kwargs):
         with PyTessBaseAPI() as api:
             with Image.open(request.FILES['image']) as image:
+                image = image.convert('RGB')
                 sharpened_image = image.filter(ImageFilter.SHARPEN)
                 api.SetImage(sharpened_image)
                 utf8_text = api.GetUTF8Text()


### PR DESCRIPTION
As per https://stackoverflow.com/questions/43267807/valueerror-cannot-filter-palette-images-during-pytesseract-conversion , this change allows pallet-based images to be converted to full RGB in order to use the PIL filters.